### PR TITLE
Removed the padding inside .grid and added margin instead on smaller …

### DIFF
--- a/_app/css/grid.css
+++ b/_app/css/grid.css
@@ -1,11 +1,15 @@
-/* Core Grid Setup */
+
+/*Grid Setup */
+.grid-container {
+    margin: 0 80px; /* Horizontal margin outside the grid */
+}
+
 .grid {
     display: grid;
     grid-template-columns: repeat(12, 1fr); /* Creates a 12-column grid */
     gap: 20px; /* Space between columns */
     margin: 0 auto; /* Centers the grid */
     max-width: 1100px; /* Maximum width of the grid */
-    padding: 0 80px; /* Padding for margins on both sides */
 }
 
 /* Column Span Classes for Larger Screens */
@@ -27,12 +31,16 @@
     grid-column-end: span 8;
 }
 
+.grid__col-start-1-span-1 {
+    grid-column-start: 1;
+}
+
 
 /* Responsive Adjustments for Smaller Screens */
 @media (max-width: 1024px) {
-    .grid {
-        padding: 0 20px; /* Adjusts padding for smaller screens */
-    }
+    .grid-container {
+        margin: 0 30px; /* Reduced horizontal margin for smaller screens */
+}
 
     /* Make all columns stack vertically on smaller screens */
     .grid__col--1, .grid__col--2, .grid__col--3, .grid__col--4,
@@ -41,7 +49,7 @@
         grid-column: 1 / -1; /* Each item spans full width */
     }
 
-    /* Mobile-specific column span classes (if needed) */
+    /* Mobile-specific column span classes*/
     .grid__col-mobile--1 { grid-column: span 1; }
     .grid__col-mobile--2 { grid-column: span 2; }
     .grid__col-mobile--3 { grid-column: span 3; }
@@ -54,5 +62,4 @@
     .grid__col-mobile--10 { grid-column: span 10; }
     .grid__col-mobile--11 { grid-column: span 11; }
     .grid__col-mobile--12 { grid-column: span 12; }
-    /* ... continue this pattern up to .grid__col-mobile--12 if needed */
 }


### PR DESCRIPTION
In the earlier commit/merge I added a container to the grid in HTML because it was causing the content inside the grid to shift position. I added the container and removed padding from the .grid inside the grid layout, and added the margin instead, but only inside mediaqueries for smaller screens. These changes made the grid and positioning of the items within it behave as expected.